### PR TITLE
[CLOSED][feat/config] - feat: add basic WAF configuration parameters (#2)

### DIFF
--- a/internal/config/config.toml
+++ b/internal/config/config.toml
@@ -27,15 +27,15 @@ timeout_ms = 200
 
 config_mode = "inline"   # "init" | "inline"
 
-# (optionnels)
-# entry_fn = "handle"
-# alloc_fn = "alloc"
-# init_fn  = "init"
-
-  [modules.config]
-  mode = "block"
-  rules_path = "/etc/edge/rules.json"
-  log = true
+[module.config]
+mode = "block"
+rules_path = "/etc/edge/rules.json"
+log = true 
+# --- ADDED BASIC PARAMETERS ---
+max_body_size_kb = 2048         # Limits request size to prevent memory exhaustion
+allowed_ips = ["127.0.0.1"]     # List of trusted IPs to bypass checks
+blocked_ips = []                # List of IPs to be immediately rejected
+paranatia_level =1              # Defines how strictly rules are applied (1-4)
 
 # -------------------------
 # RateLimit init mode (config injected at init, request without config sent at each call)


### PR DESCRIPTION
Hi @onihilist,

As discussed in issue #2, I have added several basic and mandatory parameters to the WAF module configuration in internal/config/config.toml.

Added Parameters:

max_body_size_kb: To limit request body size.

allowed_ips: For IP whitelisting.

blocked_ips: For immediate IP rejection.

paranoia_level: To set security strictness.

These parameters are now defined in the config file and ready to be utilized once the Rust logic is implemented.